### PR TITLE
fix: remove "type" field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@lovo-product/x0-js-sdk",
   "version": "0.0.14",
   "description": "provide a sdk for x0",
-  "type": "module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "license": "MIT",


### PR DESCRIPTION
build된 결과물로 cjs, esm 파일이 생성되는데 `type: "module"`이 있을 경우 cjs 문법을 지원하지 않으므로 에러가 발생합니다.